### PR TITLE
fix: align comments with arguments in multi-line instructions

### DIFF
--- a/rust-toolchain.toml
+++ b/rust-toolchain.toml
@@ -1,2 +1,2 @@
 [toolchain]
-channel = "1.75.0"
+channel = "1.96.0"

--- a/src/generation/generate.rs
+++ b/src/generation/generate.rs
@@ -87,16 +87,29 @@ fn gen_cmd_instruction<'a>(node: &'a CmdInstruction, context: &mut Context<'a>) 
 
 fn gen_copy_instruction<'a>(node: &'a CopyInstruction, context: &mut Context<'a>) -> PrintItems {
   let mut items = PrintItems::new();
-  items.push_str("COPY ");
-  for flag in node.flags.iter() {
-    items.extend(gen_node(flag.into(), context));
-    items.push_str(" ");
+  let prefix_str = "COPY ";
+  items.push_str(prefix_str);
+
+  let value_nodes = node
+    .flags
+    .iter()
+    .map(|flag| flag.into())
+    .chain(node.sources.iter().map(|source| source.into()))
+    .chain(std::iter::once((&node.destination).into()));
+  let nodes = context.gen_nodes_with_comments(node.span.start, node.span.end, value_nodes);
+
+  if nodes.iter().any(|node| node.is_comment()) {
+    // preserve comments by breaking onto multiple lines, aligned with the arguments
+    items.extend(gen_multi_line_items(nodes, prefix_str.chars().count() as u32, context));
+  } else {
+    // keep everything on a single line
+    for (i, node) in nodes.into_iter().enumerate() {
+      if i > 0 {
+        items.push_str(" ");
+      }
+      items.extend(gen_node(node, context));
+    }
   }
-  for source in node.sources.iter() {
-    items.extend(gen_node(source.into(), context));
-    items.push_str(" ");
-  }
-  items.extend(gen_node((&node.destination).into(), context));
   items
 }
 
@@ -180,7 +193,8 @@ fn gen_multi_line_items<'a>(nodes: Vec<Node<'a>>, indent_width: u32, context: &m
       (node, line_index)
     })
     .collect::<Vec<_>>();
-  let force_use_new_lines = nodes_with_line_index.len() > 1 && nodes_with_line_index[0].1 < nodes_with_line_index[1].1;
+  let force_use_new_lines = nodes_with_line_index.len() > 1
+    && (nodes_with_line_index[0].1 < nodes_with_line_index[1].1 || nodes_with_line_index.iter().any(|(node, _)| node.is_comment()));
 
   ir_helpers::gen_separated_values(
     |is_multiline| {
@@ -276,6 +290,14 @@ fn gen_breakable_string<'a>(node: &'a BreakableString, context: &mut Context<'a>
     items.push_str("\"");
   }
   for (i, component) in node.components.iter().enumerate() {
+    // comments lose their leading whitespace when parsed, so align them
+    // with the surrounding arguments by reusing their indentation
+    if matches!(component, BreakableStringComponent::Comment(_)) {
+      let indentation = comment_indentation(&node.components, i);
+      if !indentation.is_empty() {
+        items.extend(indentation.to_string().into());
+      }
+    }
     items.extend(gen_node(component.into(), context));
     if i < node.components.len() - 1 {
       if let BreakableStringComponent::String(text) = component {
@@ -294,6 +316,27 @@ fn gen_breakable_string<'a>(node: &'a BreakableString, context: &mut Context<'a>
 
   context.gen_string_content = previous_gen_string_content;
   items
+}
+
+/// Determines the indentation to use for a comment within a breakable string by
+/// reusing the leading whitespace of the closest surrounding string component.
+fn comment_indentation(components: &[BreakableStringComponent], index: usize) -> &str {
+  let following = components[index + 1..].iter().find_map(string_leading_whitespace);
+  if let Some(whitespace) = following {
+    return whitespace;
+  }
+  components[..index]
+    .iter()
+    .rev()
+    .find_map(string_leading_whitespace)
+    .unwrap_or("")
+}
+
+fn string_leading_whitespace(component: &BreakableStringComponent) -> Option<&str> {
+  match component {
+    BreakableStringComponent::String(s) => Some(&s.content[..s.content.len() - s.content.trim_start().len()]),
+    _ => None,
+  }
 }
 
 fn gen_string<'a>(node: &'a SpannedString, context: &mut Context<'a>) -> PrintItems {

--- a/tests/specs/Copy/Copy_All.txt
+++ b/tests/specs/Copy/Copy_All.txt
@@ -5,3 +5,68 @@ COPY  arr[[]0].txt    /mydir/
 [expect]
 COPY --chown=user:group --from=test source1 source2 destination/
 COPY arr[[]0].txt /mydir/
+
+== should collapse a multi-line copy without comments to a single line ==
+COPY foo \
+    bar /dest
+
+[expect]
+COPY foo bar /dest
+
+== should keep a comment in copy and align it with the arguments ==
+COPY foo \
+    # a comment
+    bar /dest
+
+[expect]
+COPY foo \
+     # a comment
+     bar \
+     /dest
+
+== should keep a comment before the destination in copy ==
+COPY foo bar \
+    # comment
+    /dest
+
+[expect]
+COPY foo \
+     bar \
+     # comment
+     /dest
+
+== should keep a comment in copy with a flag ==
+COPY --chown=user:group foo \
+    # comment
+    bar dest/
+
+[expect]
+COPY --chown=user:group \
+     foo \
+     # comment
+     bar \
+     dest/
+
+== should normalize and align a comment in copy regardless of its indentation ==
+COPY foo \
+        ##comment
+    bar /dest
+
+[expect]
+COPY foo \
+     ## comment
+     bar \
+     /dest
+
+== should keep multiple comments in copy ==
+COPY foo \
+    # comment one
+    # comment two
+    bar /dest
+
+[expect]
+COPY foo \
+     # comment one
+     # comment two
+     bar \
+     /dest

--- a/tests/specs/General/Comments_All.txt
+++ b/tests/specs/General/Comments_All.txt
@@ -55,3 +55,103 @@ ENV MY_NAME="John Doe" \
 ### test
 #### test
 #####
+
+== should keep comments aligned in run ==
+RUN exmaple \
+    -something=exmaple \
+    # Some comment
+    -Test=534324 \
+    build
+
+[expect]
+RUN exmaple \
+    -something=exmaple \
+    # Some comment
+    -Test=534324 \
+    build
+
+== should align a trailing comment in run with the previous argument ==
+RUN echo foo \
+    bar \
+    # trailing comment
+
+[expect]
+RUN echo foo \
+    bar \
+    # trailing comment
+
+== should align multiple trailing comments in run with the previous argument ==
+RUN echo foo \
+    bar \
+    # comment one
+    # comment two
+
+[expect]
+RUN echo foo \
+    bar \
+    # comment one
+    # comment two
+
+== should align multiple consecutive comments in run with the following argument ==
+RUN echo foo \
+    # comment one
+    # comment two
+    bar
+
+[expect]
+RUN echo foo \
+    # comment one
+    # comment two
+    bar
+
+== should keep run comments at column zero when arguments are not indented ==
+RUN echo foo \
+# comment
+bar
+
+[expect]
+RUN echo foo \
+# comment
+bar
+
+== should align a run comment with the following argument ignoring its own indentation ==
+RUN echo foo \
+  arg1 \
+        # comment
+    arg2
+
+[expect]
+RUN echo foo \
+  arg1 \
+    # comment
+    arg2
+
+== should align an empty comment in run with the arguments ==
+RUN echo foo \
+    #
+    bar
+
+[expect]
+RUN echo foo \
+    #
+    bar
+
+== should normalize comment chars and spacing while keeping run alignment ==
+RUN echo foo \
+    ##weird   comment
+    bar
+
+[expect]
+RUN echo foo \
+    ## weird   comment
+    bar
+
+== should align a comment after the first argument in run ==
+RUN echo foo \
+    # comment
+    bar
+
+[expect]
+RUN echo foo \
+    # comment
+    bar


### PR DESCRIPTION
Closes https://github.com/dprint/dprint-plugin-dockerfile/issues/22