### PR TITLE
docs: remove dockerfile-parser from readme

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,8 +4,6 @@
 
 Dockerfile code formatter plugin for [dprint](https://dprint.dev).
 
-This uses [dockerfile-parser](https://crates.io/crates/dockerfile-parser) to parse a dockerfile.
-
 ## Install
 
 [Install](https://dprint.dev/install/) and [setup](https://dprint.dev/setup/) dprint.

--- a/scripts/generate_release_notes.ts
+++ b/scripts/generate_release_notes.ts
@@ -14,7 +14,7 @@ ${changelog}
 
 Then in your project's dprint configuration file:
 
-1. Specify the plugin url in the \`"plugins"\` array or run \`dprint config add dockerfile\`.
+1. Run \`dprint add dockerfile\` or specify the plugin url in the \`"plugins"\` array.
 2. Add a \`"dockerfile"\` configuration property if desired.
    \`\`\`jsonc
    {


### PR DESCRIPTION
It's not used anymore.